### PR TITLE
fix: add issued time and invoice date to EInvoice class

### DIFF
--- a/uganda_compliance/efris/doctype/e_invoice/e_invoice.py
+++ b/uganda_compliance/efris/doctype/e_invoice/e_invoice.py
@@ -160,6 +160,8 @@ class EInvoice(Document):
         self.invoiceIndustryCode = 101
         self.isBatch = 0
         self.is_return = self.sales_invoice.is_return
+        self.issued_time = self.sales_invoice.posting_time
+        self.invoice_date = self.sales_invoice.posting_date
 
     def set_summary_details(self):
         self.net_amount = 0


### PR DESCRIPTION
This pull request makes a minor update to the `set_basic_information` method in the `e_invoice.py` file. The change adds two new fields, `issued_time` and `invoice_date`, which are set based on values from the associated `sales_invoice`.

- Added assignment of `issued_time` and `invoice_date` from `sales_invoice.posting_time` and `sales_invoice.posting_date` in the `set_basic_information` method of `e_invoice.py`.