### PR TITLE
fix: improve tax calculation logic in EInvoice processing and enhance logging

### DIFF
--- a/uganda_compliance/efris/api_classes/e_invoice.py
+++ b/uganda_compliance/efris/api_classes/e_invoice.py
@@ -141,13 +141,15 @@ class EInvoiceAPI:
         einvoice_json = einvoice.get_einvoice_json()
 
         company_name = sales_invoice.company
+
         integration_request_log = create_request_log(
             data=einvoice_json,
-            integration_type="Remote",
+            is_remote_request=1,
             service_name="EFRIS Generate IRN",
             reference_doctype=sales_invoice.doctype,
             reference_document=sales_invoice.name,
         )
+
         try:
             status, response = make_post(
                 interfaceCode="T109",
@@ -156,6 +158,7 @@ class EInvoiceAPI:
                 reference_doc_type=sales_invoice.doctype,
                 reference_document=sales_invoice.name,
             )
+
             if status:
                 EInvoiceAPI.handle_successful_irn_generation(einvoice, response)
                 efris_log_info(f"EFRIS Generated Successfully. :{einvoice}")
@@ -1309,6 +1312,7 @@ def calculate_additional_discounts(doc, method):
     """
     Calculate additional discounts and adjust tax values on Sales Invoice items for EFRIS compliance.
     """
+
     doc = _parse_doc(doc)
 
     efris_log_info(f"Calculate Additional Discounts called: {doc}")
@@ -1385,7 +1389,6 @@ def _process_items(doc, item_taxes, discount_percentage):
             discounted_item,
             doc.get("is_return", False),
         )
-    frappe.log_error(f"Calculated discount amounts", str(discount_amounts))
 
     return total_item_tax, total_discount_tax
 
@@ -1406,12 +1409,13 @@ def _update_row_values(
     """
     Update row values with calculated discounts and taxes.
     """
+
     values = {
         "efris_dsct_discount_total": -discount_amount if is_return else discount_amount,
         "efris_dsct_discount_tax": -discount_tax if is_return else discount_tax,
-        "efris_dsct_discount_tax_rate": f"{tax_rate / 100:.2f}"
-        if tax_rate > 0
-        else "0.0",
+        "efris_dsct_discount_tax_rate": (
+            f"{tax_rate / 100:.2f}" if tax_rate > 0 else "0.0"
+        ),
         "efris_dsct_item_tax": -item_tax if is_return else item_tax,
         "efris_dsct_taxable_amount": -row.amount if is_return else row.amount,
         "efris_dsct_item_discount": discounted_item,
@@ -1419,6 +1423,8 @@ def _update_row_values(
 
     for key, value in values.items():
         row.db_set(key, value)
+
+    frappe.db.commit()
 
 
 def decode_e_tax_rate(tax_rate, e_tax_category):

--- a/uganda_compliance/efris/doctype/e_invoice/e_invoice.py
+++ b/uganda_compliance/efris/doctype/e_invoice/e_invoice.py
@@ -466,7 +466,6 @@ class EInvoice(Document):
         self.fetch_items_from_invoice()
 
     def get_einvoice_json(self):
-
         einvoice_json = {
             "extend": {},
             "importServicesSeller": {},
@@ -670,11 +669,11 @@ class EInvoice(Document):
         discounted_item,
         discount_tax_rate,
     ):
-        # tax = (
-        #     row.efris_dsct_item_tax
-        #     if tax_rate == "0.18" and discount_percentage > 0
-        #     else row.tax
-        # )
+        tax = (
+            row.efris_dsct_item_tax
+            if tax_rate == "0.18" and discount_percentage > 0
+            else row.tax
+        )
 
         item = {
             "item": row.item_name,
@@ -684,7 +683,7 @@ class EInvoice(Document):
             "unitPrice": str(row.rate),
             "total": str(row.amount),
             "taxRate": str(tax_rate),
-            "tax": str(row.tax),
+            "tax": str(tax),
             "discountTotal": str(discount_amount) if discount_percentage > 0 else "",
             "discountTaxRate": str(discount_tax_rate),
             "orderNumber": str(order_number),
@@ -700,7 +699,7 @@ class EInvoice(Document):
 
         discount_item = None
         if discount_percentage > 0:
-            discount_tax = row.tax
+            discount_tax = row.efris_dsct_discount_tax if tax_rate == "0.18" else tax
             discount_item = {
                 "item": discounted_item,
                 "itemCode": item_code,

--- a/uganda_compliance/hooks.py
+++ b/uganda_compliance/hooks.py
@@ -234,14 +234,16 @@ app_include_js = "/assets/uganda_compliance/js/item_custom.js"
 doc_events = {
     "Sales Invoice": {
         "on_submit": "uganda_compliance.efris.api_classes.e_invoice.on_submit_sales_invoice",
-        "on_update": "uganda_compliance.efris.api_classes.e_invoice.on_update_sales_invoice",
+        "on_update": [
+            "uganda_compliance.efris.api_classes.e_invoice.on_update_sales_invoice",
+            "uganda_compliance.efris.api_classes.e_invoice.calculate_additional_discounts",
+        ],
         "on_cancel": "uganda_compliance.efris.api_classes.e_invoice.on_cancel_sales_invoice",
         "before_save": [
             "uganda_compliance.efris.api_classes.e_invoice.Sales_invoice_is_efris_validation",
             "uganda_compliance.efris.api_classes.e_invoice.sales_uom_validation",
             "uganda_compliance.efris.api_classes.e_invoice.before_save",
         ],
-        "after_save": "uganda_compliance.efris.api_classes.e_invoice.calculate_additional_discounts",
     },
     "Item": {
         "before_save": "uganda_compliance.efris.api_classes.e_goods_services.before_save_item",


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the EFRIS e-invoice integration, focusing on discount and tax calculation accuracy, code cleanup, and event handling. The main changes ensure that discount and tax values are correctly computed and reflected in both the invoice data and the EFRIS payload, while also improving database consistency and event triggering.

**Discount and Tax Calculation Accuracy:**
- Modified the logic in `_prepare_item_details` to use the correct tax value (`row.efris_dsct_item_tax`) when the tax rate is 0.18 and a discount is applied, ensuring accurate tax reporting in the EFRIS payload. Also, the discount tax for discounted items now uses `row.efris_dsct_discount_tax` when the tax rate is 0.18. [[1]](diffhunk://#diff-f28ee5907d2923c9ca05b7010e4c36e7497ecc84934f4acc8eb76c25659dcea2L673-R676) [[2]](diffhunk://#diff-f28ee5907d2923c9ca05b7010e4c36e7497ecc84934f4acc8eb76c25659dcea2L687-R686) [[3]](diffhunk://#diff-f28ee5907d2923c9ca05b7010e4c36e7497ecc84934f4acc8eb76c25659dcea2L703-R702)

**Database Consistency and Logging:**
- Added an explicit `frappe.db.commit()` after updating row values in `_update_row_values` to ensure changes are immediately persisted to the database.
- Removed unnecessary logging of discount amounts in `_process_items` to clean up log output.

**Event Handling and Hook Updates:**
- Updated the `doc_events` in `hooks.py` to trigger `calculate_additional_discounts` on the `on_update` event for Sales Invoices, ensuring discounts and taxes are recalculated on every update, and removed its previous trigger from `after_save`.

**API and Request Logging Improvements:**
- Refactored the integration request log creation in `generate_irn` to use the `is_remote_request` parameter instead of `integration_type`, aligning with updated logging conventions.
